### PR TITLE
Fix AttributeError for Undocumented Message Key

### DIFF
--- a/tests/exception.py
+++ b/tests/exception.py
@@ -1,0 +1,29 @@
+import unittest
+
+try:
+    import eway
+except:
+    from os.path import dirname, join
+    from sys import path
+    path.append(join(dirname(__file__), '..'))
+
+
+from eway.rapid.exception import EwayError, UndocumentedError
+
+
+class TestEwayError(unittest.TestCase):
+    def test_undocumented_access_code_not_found_message_has_a_custom_code(self):
+        err = EwayError.lookup_error_by_message('Access Code Not Found')
+        expected_code = 'UE001'
+        
+        self.assertEqual(err._code, expected_code)
+
+    def test_undocumented_known_message_returns_undocumented_error(self):
+        err = EwayError.lookup_error_by_message('Access Code Not Found')
+
+        self.assertIsInstance(err, UndocumentedError)
+
+    def test_undocumented_unknown_message_returns_none(self):
+        err = EwayError.lookup_error_by_message('FooBar')
+
+        self.assertIsNone(err)


### PR DESCRIPTION
Fix #5.

As discussed offline, there would be a few ways of tackling this:
1. Add a `Message = None` to the `TransactionInfo` class definition. It's the simplest but it means that wherever the client checks for `ResponseMessage`, they would also have to check for `Message` which is annoying.
1. Make `Message` a property which transparently map to `ResponseMessage`. It's still simple-ish but it has corner cases where `Message` could overwrite `ResponseMessage` and controlling the different situation where it should be or shouldn't be allowed will be complicated.
1. Map the value in `from_json` (which then calls `__init__`). It's not the simplest and there's a bit more code but the `TransactionInfo` class will not have a `Message` attribute (avoids confusion) and there's a lot less cases to consider when it comes to overriding `ResponseMessage` or not.

Also discussed offline, if both `Message` and `ResponseMessage` are present (which has never been the case so far), `ResponseMessage` will have precedence and `Message` will be silently ignored.